### PR TITLE
Add user action metrics conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: rust
 rust:
-  - nightly
+  - nightly-2020-02-07
 services:
   - docker
 
-env:
-  COMPOSE_VERSION="1.24.1"
+env: COMPOSE_VERSION="1.24.1"
 
 # Install latest nightly of rust toolchain & linter (rustfmt)
 before_install:
-  - rustup component add rustfmt --toolchain nightly
+  - rustup component add rustfmt --toolchain $TRAVIS_RUST_VERSION
 
 # Install docker-compose
 install:
@@ -29,4 +28,3 @@ script:
   - cargo fmt -- --check || travis_terminate 1; # Run lint, stop build if error
   - export SEND_REPORT=1 # Set env var to publish tarpaulin report
   - docker-compose -f test/docker-compose.tarpaulin.yaml up --exit-code-from test-rest-api # Run tests
-    

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,6 +3,7 @@ use common::proto::payload;
 use database::DbConn;
 use protobuf::ProtobufError;
 use route_handlers::authorization::find_user_by_pub_key;
+use route_handlers::prom::increment_action;
 use sawtooth_sdk::messages::batch::{Batch, BatchHeader};
 use sawtooth_sdk::messages::transaction::Transaction;
 
@@ -73,7 +74,11 @@ pub fn log_batch(conn: &DbConn, batch: &Batch) {
         None => "User not found".to_string(),
     };
     let actions = get_actions_from_batch(batch);
-    info!("{} | User: {} | Actions: {:?}", now, username, actions)
+    // Emit prometheus metric for each action
+    for action in &actions {
+        increment_action(&action, &username);
+    }
+    info!("{} | User: {} | Actions: {:?}", now, &username, &actions)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ extern crate log4rs;
 #[macro_use]
 extern crate lazy_static;
 extern crate hyper_sse;
+#[macro_use]
 extern crate prometheus;
 
 mod database;

--- a/src/route_handlers/prom.rs
+++ b/src/route_handlers/prom.rs
@@ -1,5 +1,5 @@
-use prometheus::register_counter;
-use prometheus::{labels, opts, Counter, Encoder, TextEncoder};
+use prometheus::{labels, opts, Counter, Encoder, IntCounterVec, TextEncoder};
+use prometheus::{register_counter, register_int_counter_vec};
 
 lazy_static! {
     static ref HTTP_COUNTER: Counter = register_counter!(opts!(
@@ -7,6 +7,12 @@ lazy_static! {
         "Total number of HTTP requests made.",
         labels! {"handler" => "all",}
     ))
+    .unwrap();
+    static ref ACTION_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
+        "consensource_api_actions",
+        "Who took which actions",
+        &["actions", "users"]
+    )
     .unwrap();
 }
 
@@ -22,4 +28,30 @@ pub fn get_metrics() -> String {
 
 pub fn increment_http_req() {
     HTTP_COUNTER.inc();
+}
+
+pub fn increment_action(action: &str, username: &str) {
+    ACTION_COUNTER_VEC
+        .with_label_values(&[&action, &username])
+        .inc();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_metrics_http() {
+        increment_http_req();
+        assert!(get_metrics().contains("consensource_api_http_requests_total{"));
+        assert!(get_metrics().contains("1"));
+    }
+
+    #[test]
+    fn test_get_metrics_action() {
+        increment_action("create agent", "test");
+        assert!(get_metrics().contains("consensource_api_actions"));
+        assert!(get_metrics().contains("create agent"));
+        assert!(get_metrics().contains("test"));
+    }
 }


### PR DESCRIPTION
## Proposed change/fix
- Add a Prometheus Int Counter Vec to keep track of user actions
- Increment the appropriate pair of labels during logging
- Add unit tests for metrics endpoint

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`docker-compose up` and visit [the api](http://localhost:9009/api/prom_metrics) in the browser. Perform transactions normally and verify a record of them is added by refreshing the page pointed at the metrics endpoint.
