### PR TITLE
Add user sign in metrics

### DIFF
--- a/src/route_handlers/authorization.rs
+++ b/src/route_handlers/authorization.rs
@@ -1,6 +1,6 @@
 use bcrypt::{hash, verify, BcryptError};
 use rocket_contrib::json::{Json, JsonValue};
-use route_handlers::prom::increment_http_req;
+use route_handlers::prom::{increment_http_req, increment_signin};
 
 use database::DbConn;
 use database_manager::models::User;
@@ -114,6 +114,7 @@ pub fn authenticate(payload: Json<UserAuthenticate>, conn: DbConn) -> Result<Jso
     let user_auth = payload.0;
     if let Some(user) = find_user_by_username(&conn, &user_auth.username)? {
         if verify(&user_auth.password, &user.hashed_password)? {
+            increment_signin(&user.username);
             return Ok(json!({
                 "status": "ok",
                 "username": user.username,

--- a/src/route_handlers/prom.rs
+++ b/src/route_handlers/prom.rs
@@ -14,6 +14,12 @@ lazy_static! {
         &["actions", "users"]
     )
     .unwrap();
+    static ref SIGNIN_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
+        "consensource_signins",
+        "Number of times each user has signed in",
+        &["user"]
+    )
+    .unwrap();
 }
 
 #[get("/prom_metrics")]
@@ -36,6 +42,10 @@ pub fn increment_action(action: &str, username: &str) {
         .inc();
 }
 
+pub fn increment_signin(username: &str) {
+    SIGNIN_COUNTER_VEC.with_label_values(&[&username]).inc();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -53,5 +63,12 @@ mod tests {
         assert!(get_metrics().contains("consensource_api_actions"));
         assert!(get_metrics().contains("create agent"));
         assert!(get_metrics().contains("test"));
+    }
+
+    #[test]
+    fn test_get_metrics_signin() {
+        increment_signin("testuser");
+        assert!(get_metrics().contains("consensource_signins"));
+        assert!(get_metrics().contains("testuser"));
     }
 }


### PR DESCRIPTION
## Proposed change/fix
- Add Prometheus Counter Vec to track when each user signs in
- Add call to increment in /users/authenticate with username
- Add associated unit test

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`docker-compose up` and visit [the api](http://localhost:9009/api/prom_metrics) in the browser. Sign up a new account, then log out. Sign in with the same account, and verify a new field exists with the sign in registered at the api endpoint.

To run test code, execute `cargo test test_get_metrics`