### PR TITLE
Add Assertion Support

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -61,6 +61,7 @@ fn get_action_from_transaction(transaction: &Transaction) -> String {
         payload::CertificateRegistryPayload_Action::ACCREDIT_CERTIFYING_BODY_ACTION => {
             "accredit certifying body".to_string()
         }
+        payload::CertificateRegistryPayload_Action::ASSERT_ACTION => "assertion".to_string(),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 #![feature(plugin)]
 #![feature(proc_macro_hygiene, decl_macro)]
 // 'needless_pass_by_value' lint disabled due to an issue in Rocket
@@ -99,7 +100,7 @@ fn main() {
         0 => console_log_level = LevelFilter::Warn,
         1 => console_log_level = LevelFilter::Info,
         2 => console_log_level = LevelFilter::Debug,
-        3 | _ => console_log_level = LevelFilter::Trace,
+        _ => console_log_level = LevelFilter::Trace,
     }
 
     let stdout = ConsoleAppender::builder()

--- a/src/route_handlers/assertions.rs
+++ b/src/route_handlers/assertions.rs
@@ -1,0 +1,243 @@
+use database::DbConn;
+use database_manager::custom_types::AssertionTypeEnum;
+use database_manager::models::Assertion;
+use database_manager::tables_schema::assertions;
+use diesel::prelude::*;
+use errors::ApiError;
+use paging::*;
+use rocket::request::Form;
+use rocket_contrib::json::JsonValue;
+use route_handlers::prom::increment_http_req;
+
+#[derive(Default, FromForm, Clone)]
+pub struct AssertionParams {
+    organization_id: Option<String>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+    head: Option<i64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiAssertion {
+    assertion_id: String,
+    assertor_pub_key: String,
+    assertion_type: AssertionTypeEnum,
+    object_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data_id: Option<String>,
+}
+
+impl From<Assertion> for ApiAssertion {
+    fn from(assertion: Assertion) -> Self {
+        ApiAssertion {
+            assertion_id: assertion.assertion_id.clone(),
+            assertor_pub_key: assertion.assertor_pub_key.clone(),
+            assertion_type: assertion.assertion_type,
+            object_id: assertion.object_id.clone(),
+            data_id: assertion.data_id,
+        }
+    }
+}
+
+impl<'a> From<&'a Assertion> for ApiAssertion {
+    fn from(assertion: &Assertion) -> Self {
+        ApiAssertion {
+            assertion_id: assertion.assertion_id.clone(),
+            assertor_pub_key: assertion.assertor_pub_key.clone(),
+            assertion_type: assertion.assertion_type.clone(),
+            object_id: assertion.object_id.clone(),
+            data_id: assertion.data_id.clone(),
+        }
+    }
+}
+
+#[get("/assertions/<assertion_id>")]
+pub fn fetch_assertions(assertion_id: String, conn: DbConn) -> Result<JsonValue, ApiError> {
+    fetch_assertions_with_params(assertion_id, None, conn)
+}
+
+#[get("/assertions/<assertion_id>?<params..>")]
+pub fn fetch_assertions_with_params(
+    assertion_id: String,
+    params: Option<Form<AssertionParams>>,
+    conn: DbConn,
+) -> Result<JsonValue, ApiError> {
+    // Increment HTTP request count for Prometheus metrics
+    increment_http_req();
+
+    let params = match params {
+        Some(param) => param.into_inner(),
+        None => Default::default(),
+    };
+    let head_block_num: i64 = get_head_block_num(params.head, &conn)?;
+    let assertion = assertions::table
+        .filter(assertions::assertion_id.eq(assertion_id.clone()))
+        .filter(assertions::start_block_num.le(head_block_num))
+        .filter(assertions::end_block_num.gt(head_block_num))
+        .first::<Assertion>(&*conn)
+        .optional()
+        .map_err(|err| ApiError::InternalError(err.to_string()))?;
+    let link = format!("/api/assertions/{}?head={}", assertion_id, head_block_num);
+    match assertion {
+        Some(assertion) => Ok(
+            json!({ "data": ApiAssertion::from(assertion), "link": link, "head": head_block_num }),
+        ),
+        None => Err(ApiError::NotFound(format!(
+            "No assertion with the id {} exists",
+            assertion_id
+        ))),
+    }
+}
+
+#[get("/assertions")]
+pub fn list_assertions(conn: DbConn) -> Result<JsonValue, ApiError> {
+    list_assertions_with_params(None, conn)
+}
+
+#[get("/assertions?<params..>")]
+pub fn list_assertions_with_params(
+    params: Option<Form<AssertionParams>>,
+    conn: DbConn,
+) -> Result<JsonValue, ApiError> {
+    // Increment HTTP request count for Prometheus metrics
+    increment_http_req();
+
+    let params = match params {
+        Some(param) => param.into_inner(),
+        None => Default::default(),
+    };
+    let head_block_num: i64 = get_head_block_num(params.head, &conn)?;
+    let mut assertions_query = assertions::table
+        .filter(assertions::start_block_num.le(head_block_num))
+        .filter(assertions::end_block_num.gt(head_block_num))
+        .into_boxed();
+
+    let total_count = assertions::table
+        .filter(assertions::start_block_num.le(head_block_num))
+        .filter(assertions::end_block_num.gt(head_block_num))
+        .count()
+        .get_result(&*conn)
+        .map_err(|err| ApiError::InternalError(err.to_string()))?;
+
+    let paging_info = apply_paging(params.clone(), head_block_num, total_count)?;
+
+    assertions_query = assertions_query.limit(params.limit.unwrap_or(DEFAULT_LIMIT));
+    assertions_query = assertions_query.offset(params.offset.unwrap_or(DEFAULT_OFFSET));
+
+    let assertions = assertions_query
+        .load::<Assertion>(&*conn)
+        .map_err(|err| ApiError::InternalError(err.to_string()))?;
+
+    Ok(
+        json!({ "data": assertions.iter().map(ApiAssertion::from).collect::<Vec<_>>(),
+           "link": paging_info.get("link"),
+           "head": head_block_num,
+           "paging": paging_info.get("paging")
+        }),
+    )
+}
+
+fn apply_paging(
+    params: AssertionParams,
+    head: i64,
+    total_count: i64,
+) -> Result<JsonValue, ApiError> {
+    let link = format!("/api/assertions?head={}&", head);
+
+    get_response_paging_info(params.limit, params.offset, link, total_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use database_manager::models::NewAssertion;
+    use route_handlers::tests::{get_connection_pool, run_test};
+
+    #[test]
+    /// Test that a Get to `/api/assertions/{assertion_id}` succeeds
+    /// when the agent exists with the given `public_key`
+    fn test_assertion_fetch_valid_id_success() {
+        run_test(|| {
+            let conn = get_connection_pool();
+            conn.begin_test_transaction().unwrap();
+
+            let assertion = NewAssertion {
+                start_block_num: 1,
+                end_block_num: 2,
+                assertion_id: "test_assertion_id".to_string(),
+                assertor_pub_key: "test_key".to_string(),
+                assertion_type: AssertionTypeEnum::Factory,
+                object_id: "test_object_id".to_string(),
+                data_id: None,
+            };
+            diesel::insert_into(assertions::table)
+                .values(assertion)
+                .execute(&conn)
+                .unwrap();
+            let response = fetch_assertions("test_assertion_id".to_string(), DbConn(conn));
+
+            assert_eq!(
+                response.unwrap(),
+                json!({
+                "data": {
+                    "assertion_id": "test_assertion_id".to_string(),
+                    "assertor_pub_key": "test_key".to_string(),
+                    "assertion_type": "Factory".to_string(),
+                    "object_id": "test_object_id".to_string(),
+                },
+                "head": 1 as i64,
+                "link": "/api/assertions/test_assertion_id?head=1".to_string()
+                })
+            );
+        })
+    }
+
+    #[test]
+    /// Test that a Get to `/api/assertions` returns an `Ok` response and sends back all
+    /// assertions in an array when the DB is populated
+    fn test_assertions_list_endpoint() {
+        run_test(|| {
+            let conn = get_connection_pool();
+            conn.begin_test_transaction().unwrap();
+
+            let assertion = NewAssertion {
+                start_block_num: 1,
+                end_block_num: 2,
+                assertion_id: "test_assertion_id".to_string(),
+                assertor_pub_key: "test_key".to_string(),
+                assertion_type: AssertionTypeEnum::Factory,
+                object_id: "test_object_id".to_string(),
+                data_id: None,
+            };
+            diesel::insert_into(assertions::table)
+                .values(assertion)
+                .execute(&conn)
+                .unwrap();
+
+            let response = list_assertions(DbConn(conn));
+
+            assert_eq!(
+                response.unwrap(),
+                json!({
+                    "data": [{
+                        "assertion_id": "test_assertion_id".to_string(),
+                        "assertor_pub_key": "test_key".to_string(),
+                        "assertion_type": "Factory".to_string(),
+                        "object_id": "test_object_id".to_string(),
+                    }],
+                    "head": 1 as i64,
+                    "link": "/api/assertions?head=1&limit=100&offset=0".to_string(),
+                    "paging": {
+                        "first": "/api/assertions?head=1&limit=100&offset=0".to_string(),
+                        "last": "/api/assertions?head=1&limit=100&offset=0".to_string(),
+                        "limit": 100 as i64,
+                        "next": "/api/assertions?head=1&limit=100&offset=0".to_string(),
+                        "offset": 0 as i64,
+                        "prev": "/api/assertions?head=1&limit=100&offset=0".to_string(),
+                        "total": 1 as i64,
+                    }
+                })
+            );
+        })
+    }
+}

--- a/src/route_handlers/requests.rs
+++ b/src/route_handlers/requests.rs
@@ -314,7 +314,7 @@ fn fetch_expansions(
         .into_iter()
         .fold(HashMap::new(), |mut acc, contact| {
             acc.entry(contact.organization_id.to_string())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(contact);
             acc
         });
@@ -329,7 +329,7 @@ fn fetch_expansions(
         .into_iter()
         .fold(HashMap::new(), |mut acc, authorization| {
             acc.entry(authorization.organization_id.to_string())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(authorization);
             acc
         });
@@ -368,7 +368,7 @@ fn fetch_expansions(
         .into_iter()
         .fold(HashMap::new(), |mut acc, standard_version| {
             acc.entry(standard_version.standard_id.to_string())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(standard_version);
             acc
         });

--- a/src/route_handlers/standards.rs
+++ b/src/route_handlers/standards.rs
@@ -1,6 +1,6 @@
 use database::DbConn;
 use database_manager::models::{Standard, StandardVersion};
-use database_manager::tables_schema::standards;
+use database_manager::tables_schema::{assertions, standards};
 use diesel::prelude::*;
 use errors::ApiError;
 use paging::get_head_block_num;
@@ -21,6 +21,8 @@ pub struct ApiStandard {
     organization_id: String,
     name: String,
     versions: Vec<ApiVersion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    assertion_id: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -47,6 +49,28 @@ impl From<(Standard, Vec<StandardVersion>)> for ApiStandard {
                     approval_date: version.approval_date,
                 })
                 .collect::<Vec<ApiVersion>>(),
+            assertion_id: None,
+        }
+    }
+}
+
+impl From<(Standard, Vec<StandardVersion>, Option<String>)> for ApiStandard {
+    fn from(standard_version: (Standard, Vec<StandardVersion>, Option<String>)) -> Self {
+        let (standard, version, assertion_id) = standard_version;
+        ApiStandard {
+            standard_id: standard.standard_id,
+            organization_id: standard.organization_id,
+            name: standard.name,
+            versions: version
+                .iter()
+                .map(|version| ApiVersion {
+                    version: version.version.clone(),
+                    external_link: version.link.clone(),
+                    description: version.description.clone(),
+                    approval_date: version.approval_date,
+                })
+                .collect::<Vec<ApiVersion>>(),
+            assertion_id,
         }
     }
 }
@@ -67,6 +91,28 @@ impl<'a> From<(&'a Standard, &'a Vec<StandardVersion>)> for ApiStandard {
                     approval_date: version.approval_date,
                 })
                 .collect::<Vec<ApiVersion>>(),
+            assertion_id: None,
+        }
+    }
+}
+
+impl<'a> From<(&'a Standard, &'a Vec<StandardVersion>, &'a Option<String>)> for ApiStandard {
+    fn from(standard_version: (&Standard, &Vec<StandardVersion>, &Option<String>)) -> Self {
+        let (standard, version, assertion_id) = standard_version;
+        ApiStandard {
+            standard_id: standard.standard_id.clone(),
+            organization_id: standard.organization_id.clone(),
+            name: standard.name.clone(),
+            versions: version
+                .iter()
+                .map(|version| ApiVersion {
+                    version: version.version.clone(),
+                    external_link: version.link.clone(),
+                    description: version.description.clone(),
+                    approval_date: version.approval_date,
+                })
+                .collect::<Vec<ApiVersion>>(),
+            assertion_id: assertion_id.clone(),
         }
     }
 }
@@ -92,6 +138,12 @@ pub fn list_standards_with_params(
     let mut standards_query = standards::table
         .filter(standards::start_block_num.le(head_block_num))
         .filter(standards::end_block_num.gt(head_block_num))
+        .left_join(
+            assertions::table.on(assertions::object_id
+                .eq(standards::standard_id)
+                .and(assertions::start_block_num.le(head_block_num))
+                .and(assertions::end_block_num.gt(head_block_num))),
+        )
         .into_boxed();
 
     if let Some(organization_id) = params.organization_id {
@@ -99,14 +151,20 @@ pub fn list_standards_with_params(
     }
 
     let standards = standards_query
-        .load::<Standard>(&*conn)
+        .select((
+            standards::standard_id,
+            standards::name,
+            assertions::assertion_id.nullable(),
+        ))
+        .load::<(String, String, Option<String>)>(&*conn)
         .map_err(|err| ApiError::InternalError(err.to_string()))?
         .into_iter()
-        .fold(Vec::new(), |mut acc, standard| {
+        .fold(Vec::new(), |mut acc, (id, name, assertion_id)| {
             acc.push(
                 [
-                    ("standard_id", standard.standard_id),
-                    ("standard_name", standard.name),
+                    ("standard_id", id),
+                    ("standard_name", name),
+                    ("assertion_id", assertion_id.unwrap_or_default()),
                 ]
                 .iter()
                 .cloned()
@@ -116,4 +174,109 @@ pub fn list_standards_with_params(
         });
 
     Ok(json!({ "data": standards }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use database_manager::custom_types::AssertionTypeEnum;
+    use database_manager::models::{NewAssertion, NewStandard};
+    use database_manager::tables_schema::{assertions, standards};
+    use route_handlers::tests::{get_connection_pool, run_test};
+
+    #[test]
+    /// Test that a GET to `/api/standards` returns an `Ok` response and sends back all
+    /// standards in an array when the DB is populated
+    fn test_standards_list_endpoint() {
+        run_test(|| {
+            let conn = get_connection_pool();
+            conn.begin_test_transaction().unwrap();
+
+            let standard = NewStandard {
+                start_block_num: 1,
+                end_block_num: 2,
+                standard_id: "test_standard_id".to_string(),
+                organization_id: "test_standards_body_id".to_string(),
+                name: "test_standard_name".to_string(),
+            };
+            diesel::insert_into(standards::table)
+                .values(standard)
+                .execute(&conn)
+                .unwrap();
+
+            let response = list_standards_with_params(
+                Some(Form(StandardParams {
+                    organization_id: Some("test_standards_body_id".to_string()),
+                    head: None,
+                })),
+                DbConn(conn),
+            );
+
+            assert_eq!(
+                response.unwrap(),
+                json!({
+                    "data": [{
+                        "standard_id": "test_standard_id".to_string(),
+                        "standard_name": "test_standard_name".to_string(),
+                        "assertion_id": "".to_string(),
+                    }],
+                })
+            );
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/standards` returns an `Ok` response and sends back all
+    /// standards with assertions included in an array when the DB is populated
+    fn test_standards_list_endpoint_with_assertion() {
+        run_test(|| {
+            let conn = get_connection_pool();
+            conn.begin_test_transaction().unwrap();
+
+            let standard = NewStandard {
+                start_block_num: 1,
+                end_block_num: 2,
+                standard_id: "test_standard_id".to_string(),
+                organization_id: "test_standards_body_id".to_string(),
+                name: "test_standard_name".to_string(),
+            };
+            diesel::insert_into(standards::table)
+                .values(standard)
+                .execute(&conn)
+                .unwrap();
+
+            let assertion = NewAssertion {
+                start_block_num: 1,
+                end_block_num: 2,
+                assertion_id: "test_assertion_id".to_string(),
+                assertor_pub_key: "test_key".to_string(),
+                assertion_type: AssertionTypeEnum::Standard,
+                object_id: "test_standard_id".to_string(),
+                data_id: None,
+            };
+            diesel::insert_into(assertions::table)
+                .values(assertion)
+                .execute(&conn)
+                .unwrap();
+
+            let response = list_standards_with_params(
+                Some(Form(StandardParams {
+                    organization_id: Some("test_standards_body_id".to_string()),
+                    head: None,
+                })),
+                DbConn(conn),
+            );
+
+            assert_eq!(
+                response.unwrap(),
+                json!({
+                    "data": [{
+                        "standard_id": "test_standard_id".to_string(),
+                        "standard_name": "test_standard_name".to_string(),
+                        "assertion_id": "test_assertion_id".to_string(),
+                    }],
+                })
+            );
+        })
+    }
 }

--- a/src/route_handlers/standards_body.rs
+++ b/src/route_handlers/standards_body.rs
@@ -1,6 +1,6 @@
 use database::DbConn;
 use database_manager::models::{Standard, StandardVersion};
-use database_manager::tables_schema::{standard_versions, standards};
+use database_manager::tables_schema::{assertions, standard_versions, standards};
 use diesel::prelude::*;
 use errors::ApiError;
 use paging::*;
@@ -48,7 +48,17 @@ pub fn list_standards_belonging_to_org(
         .filter(standards::organization_id.eq(params.organization_id))
         .limit(params.limit.unwrap_or(DEFAULT_LIMIT))
         .offset(params.offset.unwrap_or(DEFAULT_OFFSET))
-        .load::<Standard>(&*conn)
+        .left_join(
+            assertions::table.on(assertions::object_id
+                .eq(standards::standard_id)
+                .and(assertions::start_block_num.le(head_block_num))
+                .and(assertions::end_block_num.gt(head_block_num))),
+        )
+        .select((
+            standards::table::all_columns(),
+            assertions::assertion_id.nullable(),
+        ))
+        .load::<(Standard, Option<String>)>(&*conn)
         .map_err(|err| ApiError::InternalError(err.to_string()))?;
 
     let mut standard_version: HashMap<String, Vec<StandardVersion>> = standard_versions::table
@@ -58,7 +68,7 @@ pub fn list_standards_belonging_to_org(
             standard_versions::standard_id.eq_any(
                 standards_results
                     .iter()
-                    .map(|standard| standard.standard_id.to_string())
+                    .map(|(standard, _)| standard.standard_id.to_string())
                     .collect::<Vec<String>>(),
             ),
         )
@@ -67,20 +77,20 @@ pub fn list_standards_belonging_to_org(
         .into_iter()
         .fold(HashMap::new(), |mut acc, standard_version| {
             acc.entry(standard_version.standard_id.to_string())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(standard_version);
             acc
         });
 
     Ok(json!({ "data": standards_results.into_iter()
-                .map(|standard| {
+                .map(|(standard, assertion_id)| {
                      let standard_id = standard.standard_id.clone();
                      ApiStandard::from(
                          (standard,
                          standard_version.remove(&standard_id).map(|mut versions| {
                              versions.sort_by(|v1, v2| v1.approval_date.cmp(&v2.approval_date));
                              versions
-                         }).unwrap_or_else(|| vec![])))
+                         }).unwrap_or_else(Vec::new), assertion_id))
                 }).collect::<Vec<_>>(),
                 "link": paging_info.get("link"),
                 "paging":paging_info.get("paging")}))
@@ -94,9 +104,181 @@ fn apply_paging(
     let mut link = String::from("/api/standards_body/standards?");
 
     link = format!(
-        "{}organization_id={}&head{}=",
+        "{}organization_id={}&head={}&",
         link, params.organization_id, head
     );
 
     get_response_paging_info(params.limit, params.offset, link, total_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use database_manager::custom_types::AssertionTypeEnum;
+    use database_manager::models::{NewAssertion, NewStandard, NewStandardVersion};
+    use database_manager::tables_schema::{assertions, standard_versions, standards};
+    use route_handlers::tests::{get_connection_pool, run_test};
+
+    #[test]
+    /// Test that a GET to `/api/standards_body/standards` returns an `Ok` response and sends back all
+    /// standards of a standards body in an array when the DB is populated
+    fn test_standards_by_body_list_endpoint() {
+        run_test(|| {
+            let conn = get_connection_pool();
+            conn.begin_test_transaction().unwrap();
+
+            let standard = NewStandard {
+                start_block_num: 1,
+                end_block_num: 2,
+                standard_id: "test_standard_id".to_string(),
+                organization_id: "test_standards_body_id".to_string(),
+                name: "test_standard_name".to_string(),
+            };
+            diesel::insert_into(standards::table)
+                .values(standard)
+                .execute(&conn)
+                .unwrap();
+
+            let version = NewStandardVersion {
+                start_block_num: 1,
+                end_block_num: 2,
+                standard_id: "test_standard_id".to_string(),
+                version: "test_standard_version".to_string(),
+                link: "test_link".to_string(),
+                description: "test_description".to_string(),
+                approval_date: 1 as i64,
+            };
+
+            diesel::insert_into(standard_versions::table)
+                .values(version)
+                .execute(&conn)
+                .unwrap();
+            let response = list_standards_belonging_to_org(
+                Some(Form(StandardBodyParams {
+                    organization_id: "test_standards_body_id".to_string(),
+                    limit: None,
+                    offset: None,
+                    head: None,
+                })),
+                DbConn(conn),
+            );
+
+            assert_eq!(
+                response.unwrap(),
+                json!({
+                    "data": [{
+                        "standard_id": "test_standard_id".to_string(),
+                        "organization_id": "test_standards_body_id".to_string(),
+                        "name": "test_standard_name".to_string(),
+                        "versions": [{
+                            "version": "test_standard_version".to_string(),
+                            "external_link": "test_link".to_string(),
+                            "description": "test_description".to_string(),
+                            "approval_date": 1 as i64,
+                        }],
+                    }],
+                    "link": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                    "paging": {
+                        "first": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                        "last": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                        "limit": 100 as i64,
+                        "next": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                        "offset": 0 as i64,
+                        "prev": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                        "total": 1 as i64,
+                    }
+                })
+            );
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/standards_body/standards` returns an `Ok` response and sends back all
+    /// standards with assertions included in an array when the DB is populated
+    fn test_standards_by_body_list_endpoint_with_assertion() {
+        run_test(|| {
+            let conn = get_connection_pool();
+            conn.begin_test_transaction().unwrap();
+
+            let standard = NewStandard {
+                start_block_num: 1,
+                end_block_num: 2,
+                standard_id: "test_standard_id".to_string(),
+                organization_id: "test_standards_body_id".to_string(),
+                name: "test_standard_name".to_string(),
+            };
+            diesel::insert_into(standards::table)
+                .values(standard)
+                .execute(&conn)
+                .unwrap();
+
+            let version = NewStandardVersion {
+                start_block_num: 1,
+                end_block_num: 2,
+                standard_id: "test_standard_id".to_string(),
+                version: "test_standard_version".to_string(),
+                link: "test_link".to_string(),
+                description: "test_description".to_string(),
+                approval_date: 1 as i64,
+            };
+
+            diesel::insert_into(standard_versions::table)
+                .values(version)
+                .execute(&conn)
+                .unwrap();
+
+            let assertion = NewAssertion {
+                start_block_num: 1,
+                end_block_num: 2,
+                assertion_id: "test_assertion_id".to_string(),
+                assertor_pub_key: "test_key".to_string(),
+                assertion_type: AssertionTypeEnum::Standard,
+                object_id: "test_standard_id".to_string(),
+                data_id: None,
+            };
+            diesel::insert_into(assertions::table)
+                .values(assertion)
+                .execute(&conn)
+                .unwrap();
+
+            let response = list_standards_belonging_to_org(
+                Some(Form(StandardBodyParams {
+                    organization_id: "test_standards_body_id".to_string(),
+                    limit: None,
+                    offset: None,
+                    head: None,
+                })),
+                DbConn(conn),
+            );
+
+            assert_eq!(
+                response.unwrap(),
+                json!({
+                    "data": [{
+                        "assertion_id": "test_assertion_id".to_string(),
+                        "standard_id": "test_standard_id".to_string(),
+                        "organization_id": "test_standards_body_id".to_string(),
+                        "name": "test_standard_name".to_string(),
+                        "versions": [{
+                            "version": "test_standard_version".to_string(),
+                            "external_link": "test_link".to_string(),
+                            "description": "test_description".to_string(),
+                            "approval_date": 1 as i64,
+                        }],
+                        "assertion_id": "test_assertion_id".to_string(),
+                    }],
+                    "link": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                    "paging": {
+                        "first": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                        "last": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                        "limit": 100 as i64,
+                        "next": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                        "offset": 0 as i64,
+                        "prev": "/api/standards_body/standards?organization_id=test_standards_body_id&head=1&limit=100&offset=0".to_string(),
+                        "total": 1 as i64,
+                    }
+                })
+            );
+        })
+    }
 }

--- a/test/tables/consensource-pg-tables.sql
+++ b/test/tables/consensource-pg-tables.sql
@@ -4,7 +4,7 @@
 CREATE TYPE Role AS ENUM ('ADMIN', 'TRANSACTOR', 'UNSET_ROLE');
 CREATE TYPE OrganizationType AS ENUM ('STANDARDS_BODY', 'CERTIFYING_BODY', 'FACTORY', 'UNSET_TYPE');
 CREATE TYPE RequestStatus AS ENUM ('OPEN', 'IN_PROGRESS', 'CLOSED', 'CERTIFIED', 'UNSET_STATUS');
-
+CREATE TYPE AssertionType AS ENUM ('STANDARD', 'CERTIFICATE', 'FACTORY', 'UNSET_TYPE');
 
 -- Create tables
 
@@ -154,6 +154,19 @@ CREATE TABLE IF NOT EXISTS requests (
   request_date                BIGINT         NOT NULL
 ) INHERITS (chain_record);
 
+CREATE TABLE IF NOT EXISTS assertions (
+  id                          BIGSERIAL      PRIMARY KEY,
+  assertion_id                VARCHAR        NOT NULL,
+  assertor_pub_key            VARCHAR        NOT NULL,
+  assertion_type              AssertionType  NOT NULL,
+  object_id                   VARCHAR        NOT NULL,
+  data_id                     VARCHAR
+) INHERITS (chain_record);
+
+CREATE INDEX IF NOT EXISTS assertions_id_index ON assertions (assertion_id);
+CREATE INDEX IF NOT EXISTS assertions_object_id_index ON assertions (object_id);
+CREATE INDEX IF NOT EXISTS assertions_block_index ON assertions (end_block_num);
+
 CREATE TABLE IF NOT EXISTS retailer_factories (
   id                          BIGSERIAL      PRIMARY KEY,
   factory_id                  VARCHAR,
@@ -167,4 +180,3 @@ CREATE TABLE IF NOT EXISTS retailer_factories (
   street_line_1               VARCHAR,
   street_line_2               VARCHAR
 )
-


### PR DESCRIPTION
## Proposed change/fix

- add list and fetch endpoints for `Assertions`
- integrate assertions into `Certificate`, `Factory`, and `Standard` endpoints
- because the object of the `Assertion` is stored in these tables, mark it with an `assertion_id`
- add `clippy` suggestions and `From` impls related to `Assertions`
- add `Ingestion` org type
- update tests to share a Rocket `Client` where applicable (see `mod.rs`
- add new test pattern with diesel `begin_test_transaction`, calling route handlers directly and in same file.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test
`clip`
`cd test`
`docker-compose -f docker-compose.tarpaulin.yaml up`
