### PR TITLE
Add pg_trgm similarity filters for single fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/target/consensource-common.git?branch=master#80c8baff051db240113215993ef6401822040111"
+source = "git+https://github.com/target/consensource-common.git#80c8baff051db240113215993ef6401822040111"
 dependencies = [
  "glob 0.2.11",
  "protobuf",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "database"
 version = "0.1.0"
-source = "git+https://github.com/target/consensource-database.git?branch=master#5883358ac3f87791c7a565f313e2e7c1fe438381"
+source = "git+https://github.com/target/consensource-database.git#5883358ac3f87791c7a565f313e2e7c1fe438381"
 dependencies = [
  "diesel",
  "diesel_full_text_search",

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,9 +1,20 @@
 use diesel::pg::PgConnection;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
+use diesel::sql_function;
+use diesel::sql_types::{Nullable, Text};
 use rocket::http::Status;
 use rocket::request::{self, FromRequest};
 use rocket::{Outcome, Request, State};
 use std::ops::Deref;
+
+pub const SIMILARITY_THRESHOLD: f32 = 0.2;
+
+sql_function! {
+  /// Returns a number that indicates how similar the two arguments are.
+  /// The range of the result is zero (indicating that the two strings are completely dissimilar)
+  /// to one (indicating that the two strings are identical).
+  fn similarity(x: Nullable<Text>, y: Text) -> Float;
+}
 
 pub type PgPool = Pool<ConnectionManager<PgConnection>>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate clap;
 extern crate chrono;
 extern crate common;
 extern crate database as database_manager;
+#[macro_use]
 extern crate diesel;
 extern crate diesel_full_text_search;
 #[macro_use]

--- a/src/route_handlers/factories.rs
+++ b/src/route_handlers/factories.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use database::DbConn;
+use database::{similarity, DbConn, SIMILARITY_THRESHOLD};
 use database_manager::custom_types::OrganizationTypeEnum;
 use database_manager::models::{
     Address, Authorization, Certificate, Contact, Organization, Standard, ADDRESS_COLUMNS,
@@ -229,7 +229,8 @@ fn query_factories(
             .select(addresses::organization_id)
             .filter(addresses::start_block_num.le(head_block_num))
             .filter(addresses::end_block_num.gt(head_block_num))
-            .filter(addresses::city.eq(city.to_string()))
+            .filter(similarity(addresses::city.nullable(), city).gt(SIMILARITY_THRESHOLD))
+            .order_by(addresses::city.desc())
             .load::<String>(&*conn)?;
 
         factories_query =
@@ -242,7 +243,8 @@ fn query_factories(
             .select(addresses::organization_id)
             .filter(addresses::start_block_num.le(head_block_num))
             .filter(addresses::end_block_num.gt(head_block_num))
-            .filter(addresses::state_province.eq(state_province.to_string()))
+            .filter(similarity(addresses::state_province, state_province).gt(SIMILARITY_THRESHOLD))
+            .order_by(addresses::state_province.desc())
             .load::<String>(&*conn)?;
 
         factories_query =
@@ -255,7 +257,8 @@ fn query_factories(
             .select(addresses::organization_id)
             .filter(addresses::start_block_num.le(head_block_num))
             .filter(addresses::end_block_num.gt(head_block_num))
-            .filter(addresses::country.eq(country.to_string()))
+            .filter(similarity(addresses::country.nullable(), country).gt(SIMILARITY_THRESHOLD))
+            .order_by(addresses::country.desc())
             .load::<String>(&*conn)?;
 
         factories_query =
@@ -268,7 +271,10 @@ fn query_factories(
             .select(addresses::organization_id)
             .filter(addresses::start_block_num.le(head_block_num))
             .filter(addresses::end_block_num.gt(head_block_num))
-            .filter(addresses::postal_code.eq(postal_code.to_string()))
+            .filter(
+                similarity(addresses::postal_code.nullable(), postal_code).gt(SIMILARITY_THRESHOLD),
+            )
+            .order_by(addresses::postal_code.desc())
             .load::<String>(&*conn)?;
 
         factories_query =

--- a/src/route_handlers/factories.rs
+++ b/src/route_handlers/factories.rs
@@ -531,6 +531,154 @@ mod tests {
     }
 
     #[test]
+    /// Test that a GET to `/api/factories?city=assertion` returns an `Ok` response
+    /// with a factory of similarity greater than 0.2
+    fn test_factories_list_with_similar_city_param() {
+        run_test(|| {
+            let conn = setup_factory_db(false);
+
+            let mut factory_city_params = FACTORY_PARAMS_BASE.clone();
+            let factory_city = String::from(format!("{}_city_similar", FACTORY_NAME_BASE));
+            factory_city_params.city = Some(factory_city);
+
+            let res = list_factories_params(Some(Form(factory_city_params)), DbConn(conn));
+            let num_factories = res.unwrap().get("data").unwrap().as_array().unwrap().len();
+
+            assert_eq!(num_factories, 1);
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/factories?city=assertion` returns an `Ok` response
+    /// with a factory of similarity less than 0.2
+    fn test_factories_list_with_dissimilar_city_param() {
+        run_test(|| {
+            let conn = setup_factory_db(false);
+
+            let mut factory_city_params = FACTORY_PARAMS_BASE.clone();
+            let factory_city = String::from("dissimilar_city");
+            factory_city_params.city = Some(factory_city);
+
+            let res = list_factories_params(Some(Form(factory_city_params)), DbConn(conn));
+            let num_factories = res.unwrap().get("data").unwrap().as_array().unwrap().len();
+
+            assert_eq!(num_factories, 0);
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/factories?state_province=assertion` returns an `Ok` response
+    /// with a factory of similarity greater than 0.2
+    fn test_factories_list_with_similar_state_province_param() {
+        run_test(|| {
+            let conn = setup_factory_db(false);
+
+            let mut factory_state_province_params = FACTORY_PARAMS_BASE.clone();
+            let factory_state_province =
+                String::from(format!("{}_state_province_similar", FACTORY_NAME_BASE));
+            factory_state_province_params.state_province = Some(factory_state_province);
+
+            let res =
+                list_factories_params(Some(Form(factory_state_province_params)), DbConn(conn));
+            let num_factories = res.unwrap().get("data").unwrap().as_array().unwrap().len();
+
+            assert_eq!(num_factories, 1);
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/factories?state_province=assertion` returns an `Ok` response
+    /// with a factory of similarity less than 0.2
+    fn test_factories_list_with_dissimilar_state_province_param() {
+        run_test(|| {
+            let conn = setup_factory_db(false);
+
+            let mut factory_state_province_params = FACTORY_PARAMS_BASE.clone();
+            let factory_state_province = String::from("dissimilar_sp");
+            factory_state_province_params.state_province = Some(factory_state_province);
+
+            let res =
+                list_factories_params(Some(Form(factory_state_province_params)), DbConn(conn));
+            let num_factories = res.unwrap().get("data").unwrap().as_array().unwrap().len();
+
+            assert_eq!(num_factories, 0);
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/factories?country=assertion` returns an `Ok` response
+    /// with a factory of similarity greater than 0.2
+    fn test_factories_list_with_similar_country_param() {
+        run_test(|| {
+            let conn = setup_factory_db(false);
+
+            let mut factory_country_params = FACTORY_PARAMS_BASE.clone();
+            let factory_country = String::from(format!("{}_country_similar", FACTORY_NAME_BASE));
+            factory_country_params.country = Some(factory_country);
+
+            let res = list_factories_params(Some(Form(factory_country_params)), DbConn(conn));
+            let num_factories = res.unwrap().get("data").unwrap().as_array().unwrap().len();
+
+            assert_eq!(num_factories, 1);
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/factories?country=assertion` returns an `Ok` response
+    /// with a factory of similarity less than 0.2
+    fn test_factories_list_with_dissimilar_country_param() {
+        run_test(|| {
+            let conn = setup_factory_db(false);
+
+            let mut factory_country_params = FACTORY_PARAMS_BASE.clone();
+            let factory_country = String::from("dissimilar_ctry");
+            factory_country_params.country = Some(factory_country);
+
+            let res = list_factories_params(Some(Form(factory_country_params)), DbConn(conn));
+            let num_factories = res.unwrap().get("data").unwrap().as_array().unwrap().len();
+
+            assert_eq!(num_factories, 0);
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/factories?postal_code=assertion` returns an `Ok` response
+    /// with a factory of similarity greater than 0.2
+    fn test_factories_list_with_similar_postal_code_param() {
+        run_test(|| {
+            let conn = setup_factory_db(false);
+
+            let mut factory_postal_code_params = FACTORY_PARAMS_BASE.clone();
+            let factory_postal_code =
+                String::from(format!("{}_postal_code_similar", FACTORY_NAME_BASE));
+            factory_postal_code_params.postal_code = Some(factory_postal_code);
+
+            let res = list_factories_params(Some(Form(factory_postal_code_params)), DbConn(conn));
+            let num_factories = res.unwrap().get("data").unwrap().as_array().unwrap().len();
+
+            assert_eq!(num_factories, 1);
+        })
+    }
+
+    #[test]
+    /// Test that a GET to `/api/factories?postal_code=assertion` returns an `Ok` response
+    /// with a factory of similarity less than 0.2
+    fn test_factories_list_with_dissimilar_postal_code_param() {
+        run_test(|| {
+            let conn = setup_factory_db(false);
+
+            let mut factory_postal_code_params = FACTORY_PARAMS_BASE.clone();
+            let factory_postal_code = String::from("dissimilar_code");
+            factory_postal_code_params.postal_code = Some(factory_postal_code);
+
+            let res = list_factories_params(Some(Form(factory_postal_code_params)), DbConn(conn));
+            let num_factories = res.unwrap().get("data").unwrap().as_array().unwrap().len();
+
+            assert_eq!(num_factories, 0);
+        })
+    }
+
+    #[test]
     /// Test that the `search` param will match on the standard name of certs that the factory holds
     fn test_factories_list_endpoint_with_search_param_cert_std_name() {
         run_test(|| {

--- a/test/tables/consensource-pg-tables.sql
+++ b/test/tables/consensource-pg-tables.sql
@@ -1,4 +1,7 @@
 
+-- Add pg_trgm extension for similarity index searches
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
 -- Create custom types
 
 CREATE TYPE Role AS ENUM ('ADMIN', 'TRANSACTOR', 'UNSET_ROLE');
@@ -107,6 +110,9 @@ CREATE TABLE IF NOT EXISTS addresses (
 CREATE INDEX IF NOT EXISTS addresses_organization_id_index ON addresses (organization_id);
 CREATE INDEX IF NOT EXISTS addresses_block_index ON addresses (end_block_num);
 CREATE INDEX IF NOT EXISTS address_text_search ON addresses USING GIN (text_searchable_address_col);
+CREATE INDEX address_city_trgm_idx ON addresses USING GIST (city gist_trgm_ops);
+CREATE INDEX address_state_trgm_idx ON addresses USING GIST (state_province gist_trgm_ops);
+CREATE INDEX address_country_trgm_idx ON addresses USING GIST (country gist_trgm_ops);
 
 CREATE TRIGGER tsvectorupdateaddresses BEFORE INSERT OR UPDATE
 ON addresses FOR EACH ROW EXECUTE PROCEDURE


### PR DESCRIPTION
## Proposed change/fix

`/factories`
- [x] `city`
- [x] `state_province`
- [x] `country`
- [x] `postal_code`

Do we want the following just so it's available? **UPDATE** Will make a separate ticket for the work below

`/cetificates`
- [ ] `certifying_body_id`
- [ ] `standard_version`

`/standards`
- [ ] `name`

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

TBD